### PR TITLE
fix missing emit

### DIFF
--- a/contracts/TokenERC20.sol
+++ b/contracts/TokenERC20.sol
@@ -39,6 +39,8 @@ contract TokenERC20 {
         balanceOf[msg.sender] = totalSupply;                // Give the creator all initial tokens
         name = tokenName;                                   // Set the name for display purposes
         symbol = tokenSymbol;                               // Set the symbol for display purposes
+        emit Transfer(address(0), msg.sender, totalSupply);
+
     }
 
     /**


### PR DESCRIPTION
based on the protocol, a Transfer event should be emitted.
“A token contract which creates new tokens SHOULD trigger a Transfer event with the _from address set to 0x0 when tokens are created.”
from https://eips.ethereum.org/EIPS/eip-20

So this fix just simply emits a transfer event when a new token is created.